### PR TITLE
(bc) Add home route and remove uri conversion

### DIFF
--- a/src/controllers/RoutesController.php
+++ b/src/controllers/RoutesController.php
@@ -42,15 +42,7 @@ class RoutesController extends Controller
             if (!$uriFormat) {
                 break;
             }
-            // If we have more than one dynamic parameter, convert it to a rest param
-            if (str_contains($uriFormat, '}/{')) {
-                $uriFormats[] = '[...uri]';
-                break;
-            }
-            // If it is not the home section, add it
-            if ($uriFormat != '__home__') {
-                $uriFormats[] = $uriFormat;
-            }
+            $uriFormats[] = $uriFormat;
         }
         $uriFormats = array_unique($uriFormats);
         if (!$uriFormats) {


### PR DESCRIPTION
I changed my mind and I now think its not the place of the plugin to exclude the home route and convert uri formats. This should be left to the API consumer.